### PR TITLE
tmux + tmuxinator 開発環境構築ガイド記事の追加

### DIFF
--- a/articles/1b7eb1a3fc3787.md
+++ b/articles/1b7eb1a3fc3787.md
@@ -1,0 +1,351 @@
+---
+title: "macOS + iTerm2 + tmux + tmuxinator で Claude Code 開発環境を構築する"
+emoji: "🖥"
+type: "tech"
+topics: ["tmux", "tmuxinator", "iterm2", "macos", "claudecode"]
+published: false
+---
+
+この記事では、macOS 上で iTerm2・tmux・tmuxinator を組み合わせた開発環境を構築します。Claude Code・nvim・コマンドラインを同時に使える環境を、上から順に実行するだけで整えられます。tmux を初めて使う方にも対応しています。
+
+## 1. tmux のインストール
+
+Homebrew を使って tmux をインストールします。
+
+```bash
+brew install tmux
+```
+
+インストールが完了したら、バージョンを確認します。
+
+```bash
+tmux -V
+```
+
+`tmux 3.x` のようにバージョンが表示されれば OK です。
+
+## 2. tmux の基本設定
+
+tmux の設定ファイル `~/.tmux.conf` を作成します。以下の内容をそのままコピーしてください。
+
+```bash
+cat << 'EOF' > ~/.tmux.conf
+# ====================
+# prefix キーを Ctrl+a に変更
+# ====================
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
+
+# ====================
+# 基本設定
+# ====================
+# マウス操作を有効にする（スクロール・pane選択・リサイズ）
+set -g mouse on
+
+# コピーモードで vim 風キーバインドを使う
+setw -g mode-keys vi
+
+# スクロールバッファを増やす（デフォルト 2000）
+set -g history-limit 100000
+
+# pane・window のインデックスを 1 から始める（0 は押しにくい）
+set -g base-index 1
+setw -g pane-base-index 1
+EOF
+```
+
+設定の意味を簡単にまとめます。
+
+| 設定 | 説明 |
+| --- | --- |
+| `prefix C-a` | prefix キーを `Ctrl+b`（デフォルト）から `Ctrl+a` に変更。片手で押しやすい |
+| `mouse on` | マウスで pane の選択・リサイズ・スクロールができるようになる |
+| `mode-keys vi` | コピーモードで `hjkl` 移動や `v` で範囲選択ができる |
+| `history-limit 100000` | スクロールバッファを 10 万行に拡大。ログが多い作業でも安心 |
+| `base-index 1` | window・pane の番号を 1 始まりにする |
+
+## 3. tmux Plugin Manager（TPM）の導入
+
+TPM を使うと、tmux のプラグインを簡単に管理できます。
+
+### TPM のインストール
+
+```bash
+git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+```
+
+### .tmux.conf にプラグイン設定を追加
+
+`~/.tmux.conf` の末尾に以下を追記します。
+
+```bash
+cat << 'EOF' >> ~/.tmux.conf
+
+# ====================
+# プラグイン（TPM）
+# ====================
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# TPM を起動（この行は .tmux.conf の最後に置くこと）
+run '~/.tmux/plugins/tpm/tpm'
+EOF
+```
+
+各プラグインの役割は以下のとおりです。
+
+| プラグイン       | 説明                                                                  |
+| ---------------- | --------------------------------------------------------------------- |
+| `tmux-sensible`  | 多くのユーザーが共通で使う「妥当な」デフォルト設定をまとめて適用する  |
+| `tmux-resurrect` | tmux のセッション（window・pane の配置やコマンド）を保存・復元できる  |
+| `tmux-continuum` | resurrect の保存を自動化し、tmux 起動時に自動復元する                 |
+| `tmux-yank`      | tmux のコピーモードでコピーした内容をシステムクリップボードに反映する |
+
+### プラグインのインストール
+
+tmux を起動した状態で、以下のキーを押します。
+
+```text
+Ctrl+a → Shift+i
+```
+
+画面下部にインストール進捗が表示され、完了すると自動で元の画面に戻ります。
+
+## 4. tmux の便利設定
+
+操作性を向上させる設定を `~/.tmux.conf` に追記します。
+
+```bash
+cat << 'EOF' >> ~/.tmux.conf
+
+# ====================
+# 便利設定
+# ====================
+# prefix + r で設定ファイルをリロード
+bind r source-file ~/.tmux.conf \; display "tmux config reloaded"
+
+# pane 移動（prefix 不要で Ctrl+h/j/k/l）
+bind -n C-h select-pane -L
+bind -n C-j select-pane -D
+bind -n C-k select-pane -U
+bind -n C-l select-pane -R
+
+# pane リサイズ（prefix + H/J/K/L）
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# ステータスバー
+set -g status-position top
+set -g status-interval 5
+set -g status-style "bg=colour235,fg=colour136"
+set -g status-left "#[fg=colour39,bold] #S "
+set -g status-right "#[fg=colour244] %Y-%m-%d %H:%M "
+set -g status-left-length 30
+EOF
+```
+
+| 設定                     | 説明                                                                  |
+| ------------------------ | --------------------------------------------------------------------- |
+| `bind r source-file ...` | `Ctrl+a` → `r` で `.tmux.conf` を再読み込み。設定変更をすぐ反映できる |
+| `bind -n C-h/j/k/l`      | prefix なしで `Ctrl+h/j/k/l` を押すだけで pane を移動できる           |
+| `bind -r H/J/K/L`        | `Ctrl+a` → `H/J/K/L` で pane のサイズを 5 セルずつ調整する            |
+| `status-position top`    | ステータスバーを画面上部に配置する                                    |
+
+設定を追記したら、リロードします。
+
+```bash
+tmux source-file ~/.tmux.conf
+```
+
+## 5. tmux-resurrect / continuum の設定
+
+セッションの自動保存・自動復元を有効にします。`~/.tmux.conf` に以下を追記してください。
+
+```bash
+cat << 'EOF' >> ~/.tmux.conf
+
+# ====================
+# セッション保存・復元
+# ====================
+# tmux 起動時に前回のセッションを自動復元
+set -g @continuum-restore 'on'
+
+# 15分ごとにセッションを自動保存
+set -g @continuum-save-interval '15'
+EOF
+```
+
+### 手動で保存・復元する
+
+自動保存に加えて、任意のタイミングで手動操作もできます。
+
+| 操作             | キー                |
+| ---------------- | ------------------- |
+| セッションを保存 | `Ctrl+a` → `Ctrl+s` |
+| セッションを復元 | `Ctrl+a` → `Ctrl+r` |
+
+マシンを再起動しても、保存した window・pane の配置とカレントディレクトリが復元されます。
+
+## 6. tmux の基本操作チートシート
+
+ここまでの設定を前提に、よく使う操作をまとめます。prefix キーはすべて `Ctrl+a` です。
+
+### pane 操作
+
+| 操作              | キー                   |
+| ----------------- | ---------------------- |
+| 左右に分割        | `Ctrl+a` → `%`         |
+| 上下に分割        | `Ctrl+a` → `"`         |
+| pane を閉じる     | `Ctrl+d` または `exit` |
+| pane を移動（左） | `Ctrl+h`               |
+| pane を移動（下） | `Ctrl+j`               |
+| pane を移動（上） | `Ctrl+k`               |
+| pane を移動（右） | `Ctrl+l`               |
+
+### window 操作
+
+| 操作                 | キー           |
+| -------------------- | -------------- |
+| 新しい window を作成 | `Ctrl+a` → `c` |
+| 次の window に移動   | `Ctrl+a` → `n` |
+| 前の window に移動   | `Ctrl+a` → `p` |
+| window 一覧を表示    | `Ctrl+a` → `w` |
+
+### セッション操作
+
+| 操作                        | キー / コマンド          |
+| --------------------------- | ------------------------ |
+| デタッチ（tmux を裏に回す） | `Ctrl+a` → `d`           |
+| セッション一覧              | `tmux ls`                |
+| セッションにアタッチ        | `tmux a -t セッション名` |
+
+## 7. tmuxinator の導入
+
+tmuxinator は tmux のセッション構成を YAML で定義し、コマンド一発で起動できるツールです。
+
+### インストール
+
+```bash
+brew install tmuxinator
+```
+
+### シェルの補完を有効にする（zsh の場合）
+
+```bash
+echo 'source $(brew --prefix)/opt/tmuxinator/etc/bash_completion.d/tmuxinator.zsh' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### プロジェクト定義を作成
+
+```bash
+tmuxinator new claude
+```
+
+エディタが開くので、続けてセクション 8 の YAML を入力してください。
+
+## 8. Claude Code 用 tmuxinator 設定
+
+`~/.config/tmuxinator/claude.yml` を以下の内容にします。
+
+```yaml
+name: claude
+root: ~/project
+
+windows:
+  - dev:
+      layout: main-horizontal
+      panes:
+        - claude:
+            - claude
+        - nvim:
+            - nvim .
+        - shell:
+            - echo "Ready"
+
+  - logs:
+      panes:
+        - shell:
+            - echo "logs window"
+```
+
+### 設定の説明
+
+| キー      | 説明                                                                     |
+| --------- | ------------------------------------------------------------------------ |
+| `name`    | tmux セッション名。`tmux ls` で表示される                                |
+| `root`    | すべての pane のカレントディレクトリ。プロジェクトに合わせて変更する     |
+| `windows` | 作成する window のリスト                                                 |
+| `layout`  | pane の配置。`main-horizontal` は上に大きな pane、下に小さな pane が並ぶ |
+| `panes`   | 各 pane で実行するコマンド                                               |
+
+`root` はプロジェクトに合わせて書き換えてください。例えば `~/projects/my-app` など。
+
+## 9. tmuxinator でセッションを起動する
+
+以下のコマンドで、定義した構成の tmux セッションが一発で立ち上がります。
+
+```bash
+tmuxinator start claude
+```
+
+起動すると、以下の状態になります。
+
+- **window: dev** — Claude Code・nvim・シェルの 3 pane が開く
+- **window: logs** — ログ確認用のシェルが開く
+
+`Ctrl+h/j/k/l` で pane 間を移動し、`Ctrl+a` → `n`/`p` で window を切り替えます。
+
+## 10. セッションの終了
+
+### デタッチ（セッションを維持したまま抜ける）
+
+```text
+Ctrl+a → d
+```
+
+デタッチした後は `tmuxinator start claude` または `tmux a -t claude` で再接続できます。
+
+### セッションを終了する
+
+```bash
+tmux kill-session -t claude
+```
+
+### すべての tmux セッションを終了する
+
+```bash
+tmux kill-server
+```
+
+`kill-server` はすべてのセッションを強制終了します。他に動いているセッションがないか確認してから実行してください。
+
+## 完成した環境の構成図
+
+```text
+iTerm2
+  └─ tmux session: claude
+       │
+       ├─ window 1: dev (main-horizontal layout)
+       │     ┌──────────────────────────────┐
+       │     │         Claude Code           │
+       │     │    (AI アシスタント)            │
+       │     ├──────────────┬───────────────┤
+       │     │    nvim      │    shell      │
+       │     │ (エディタ)    │ (コマンド実行) │
+       │     └──────────────┴───────────────┘
+       │
+       └─ window 2: logs
+             ┌──────────────────────────────┐
+             │           shell              │
+             │      (ログ確認用)              │
+             └──────────────────────────────┘
+```
+
+Claude Code で指示を出しながら、nvim でコードを編集し、shell でコマンドを実行できます。この 3 つを pane 移動だけで切り替えられる環境の完成です。


### PR DESCRIPTION
## Summary

- macOS + iTerm2 + tmux + tmuxinator で Claude Code 開発環境を構築する手順記事を追加
- tmux の基本設定・プラグイン導入・便利設定・チートシートを網羅
- tmuxinator で Claude Code / nvim / shell を一発起動できる YAML 設定を提供

## Test plan

- [ ] `npx zenn preview` でローカルプレビューし、記事の表示を確認
- [ ] コードブロック・表・ASCII 図が正しくレンダリングされることを確認
- [ ] 手順を上から順に実行して環境構築できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a comprehensive guide for setting up a Claude Code development environment on macOS, including step-by-step instructions for tmux and tmuxinator configuration, plugin management, session persistence setup, and a practical command reference cheat sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->