### PR TITLE
fmt.Sprintf go.mod インジェクション記事を公開

### DIFF
--- a/articles/c10431f5afd26d.md
+++ b/articles/c10431f5afd26d.md
@@ -35,7 +35,7 @@ os.WriteFile("go.mod", []byte(modContent), 0o644)
 `goVersion` に改行を含む値を注入するケースを考えます。ユーザーの `go.mod` ファイルが何らかの方法で改ざんされ、Go バージョンフィールドに以下の値が設定されていた場合を想定してみましょう。
 
 ```text
-1.22\n\nreplace example.com/lib => github.com/attacker/malicious v1.0.0
+1.22\n\nrequire example.com/lib v0.0.0\n\nreplace example.com/lib => /legitimate/path\n\nreplace example.com/lib => github.com/attacker/malicious v1.0.0
 ```
 
 生成される `go.mod` はこうなります。
@@ -45,6 +45,10 @@ module build
 
 go 1.22
 
+require example.com/lib v0.0.0
+
+replace example.com/lib => /legitimate/path
+
 replace example.com/lib => github.com/attacker/malicious v1.0.0
 
 require example.com/lib v0.0.0
@@ -52,7 +56,7 @@ require example.com/lib v0.0.0
 replace example.com/lib => /legitimate/path
 ```
 
-`replace` ディレクティブが2つ存在する状態になります。Go のモジュールシステムでは、同一モジュールに対する `replace` が複数ある場合、後に記述された方が優先されます（[Go Modules Reference](https://go.dev/ref/mod)）。この例では攻撃者が注入した `replace` が先に来るため、正規のパスで上書きされますが、注入位置を変えれば攻撃者側を後勝ちにできます。
+`replace` ディレクティブが重複している点に注目してください。Go のモジュールシステムでは、同一モジュールに対する `replace` が複数ある場合、後に記述された方が優先されます（[Go Modules Reference](https://go.dev/ref/mod)）。この例では正規の `replace` より後に攻撃者の `replace` が来るため、悪意あるモジュールへの差し替えが成立します。
 
 ## 攻撃シナリオ2: モジュールパスの改ざん
 
@@ -98,14 +102,11 @@ func sanitizeGoVersion(ver string) (string, error) {
 }
 
 func buildModContent(goVersion, modRoot string) (string, error) {
-    // Go バージョンのホワイトリスト検証
+    // Go バージョンのホワイトリスト検証（数字とドットのみ許可）
     if _, err := sanitizeGoVersion(goVersion); err != nil {
         return "", err
     }
-    // 改行文字のチェック
-    if strings.ContainsAny(goVersion, "\n\r") {
-        return "", fmt.Errorf("go version contains invalid characters: %q", goVersion)
-    }
+    // modRoot の改行文字チェック
     if strings.ContainsAny(modRoot, "\n\r") {
         return "", fmt.Errorf("module root path contains invalid characters: %q", modRoot)
     }


### PR DESCRIPTION
## Summary
- 「fmt.Sprintf で go.mod を生成するとインジェクションされる」記事を公開状態に変更

## Test plan
- [ ] プレビューで記事の表示を確認
- [ ] Zenn での公開を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation and sanitization guidance—including explicit newline checks and version validation—to prevent unsafe or malformed module content.

* **Documentation**
  * Broadened scope to cover structured text outputs (YAML, Dockerfile, .env) alongside module files.
  * Rewrote examples and narrative to favor structured APIs, show safer generation patterns, and clarify remediation steps and conclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->