### PR TITLE
⬆️ bump zenn-cli from 0.4.5 to 0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zenn-cli": "^0.4.5"
+        "zenn-cli": "^0.4.6"
       },
       "devDependencies": {
         "husky": "^9.1.7",
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2615,9 +2615,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8568,9 +8568,9 @@
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.4.5.tgz",
-      "integrity": "sha512-lrG5Bb8j8jhVKRLE1T6Fe/wYV+jBDaRZFHzDatS/tcxcoV1oNaK812PeXYr2rtvH77trZaIag6fYltGXAIN0oA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.4.6.tgz",
+      "integrity": "sha512-jeC65M6Xx8wVGL2E7+Siw+qlhUurg+Y7w4HwMDMzgNrbrCROs836qKE4kq77oqkUcbXrcRVbSAXnjAKVTA2oNg==",
       "license": "MIT",
       "dependencies": {
         "open": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "textlint-rule-preset-ja-technical-writing": "^12.0.2"
   },
   "dependencies": {
-    "zenn-cli": "^0.4.5"
+    "zenn-cli": "^0.4.6"
   },
   "lint-staged": {
     "*.md": [


### PR DESCRIPTION
## Summary

- `zenn-cli` を 0.4.5 から 0.4.6 にアップグレード
- 関連依存パッケージ（hono, @hono/node-server）も併せて更新

## Test plan

- [ ] `npm install` が正常に完了すること
- [ ] `npx zenn preview` でローカルプレビューが動作すること
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->