### PR TITLE
🐛 fix: depguard URL を訂正し archunit を kcmvp 版へ差し替え

### DIFF
--- a/articles/7d2428cbcd258d.md
+++ b/articles/7d2428cbcd258d.md
@@ -99,7 +99,7 @@ Go言語ではパッケージの循環importはコンパイルエラーになる
 
 ## depguard によるインポート制限の設定
 
-[depguard](https://github.com/OpenPolicyAgent/depguard)は、パッケージごとに許可・拒否するimportを宣言的に設定できるツールです。[golangci-lint](https://golangci-lint.run/)に組み込まれているため、既存のlint環境にすぐ導入できます。
+[depguard](https://github.com/OpenPeeDeeP/depguard)は、パッケージごとに許可・拒否するimportを宣言的に設定できるツールです。[golangci-lint](https://golangci-lint.run/)に組み込まれているため、既存のlint環境にすぐ導入できます。
 
 ### 基本設定
 
@@ -193,9 +193,9 @@ go-cleanarchの利点は、**設定ファイル不要**で導入コストが低�
 
 ---
 
-## archunit-go による柔軟なアーキテクチャテスト
+## archunit によるテストとしての依存性検証
 
-[archunit-go](https://github.com/nicognaW/archunit-go)は、Goのテストコードの中でアーキテクチャルールを宣言的に記述できるライブラリです。JVM向けの[ArchUnit](https://www.archunit.org/)にインスパイアされています。
+[kcmvp/archunit](https://github.com/kcmvp/archunit)は、Goのテストコードの中でアーキテクチャルールを宣言的に記述できるライブラリです。JVM向けの[ArchUnit](https://www.archunit.org/)にインスパイアされており、レイヤーを定義してから依存方向を検証する流れで利用します。
 
 ### テストコードでルールを定義
 
@@ -206,42 +206,45 @@ package architecture_test
 import (
     "testing"
 
-    archunit "github.com/nicognaW/archunit-go"
+    "github.com/kcmvp/archunit"
 )
 
 func TestDependencyRule(t *testing.T) {
-    t.Run("domain層は外側のレイヤーに依存しない", func(t *testing.T) {
-        archunit.Package(t, "myapp/internal/order/domain/...").
-            ShouldNotDependOn(
-                "myapp/internal/order/usecase/...",
-                "myapp/internal/order/interface/...",
-                "myapp/internal/order/infrastructure/...",
-            )
-    })
+    domain := archunit.ArchLayer("Domain", "myapp/internal/order/domain/...")
+    usecase := archunit.ArchLayer("UseCase", "myapp/internal/order/usecase/...")
+    iface := archunit.ArchLayer("Interface", "myapp/internal/order/interface/...")
+    infra := archunit.ArchLayer("Infrastructure", "myapp/internal/order/infrastructure/...")
 
-    t.Run("usecase層はinterface層とinfrastructure層に依存しない", func(t *testing.T) {
-        archunit.Package(t, "myapp/internal/order/usecase/...").
-            ShouldNotDependOn(
-                "myapp/internal/order/interface/...",
-                "myapp/internal/order/infrastructure/...",
-            )
-    })
+    arch := archunit.ArchUnit(domain, usecase, iface, infra)
 
-    t.Run("interface層はinfrastructure層に依存しない", func(t *testing.T) {
-        archunit.Package(t, "myapp/internal/order/interface/...").
-            ShouldNotDependOn(
-                "myapp/internal/order/infrastructure/...",
-            )
-    })
+    err := arch.Validate(
+        archunit.Layers("Domain").ShouldNotRefer(
+            archunit.Layers("UseCase"),
+            archunit.Layers("Interface"),
+            archunit.Layers("Infrastructure"),
+        ),
+        archunit.Layers("UseCase").ShouldNotRefer(
+            archunit.Layers("Interface"),
+            archunit.Layers("Infrastructure"),
+        ),
+        archunit.Layers("Interface").ShouldNotRefer(
+            archunit.Layers("Infrastructure"),
+        ),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
 }
 ```
 
-### archunit-goの利点
+`ArchLayer`でレイヤーを命名し、`ArchUnit`にまとめてから`Validate`にルールを渡します。`ShouldNotRefer`は「左辺のレイヤーが右辺のレイヤーをimportしてはいけない」という制約を意味します。
 
-archunit-goには他のツールにない特長があります。
+### archunit の利点
+
+archunit には他のツールにない特長があります。
 
 - **Goのテストとして実行できる**: `go test`で依存性ルールを検証でき、既存のテスト基盤にそのまま組み込めます
-- **柔軟なルール定義**: パッケージ単位だけでなく、特定の例外を許可するルールも書けます
+- **レイヤーに名前を付けられる**: ルール宣言が「Domain は Infrastructure を参照しない」という自然言語に近い表現で書けます
 - **テストレポートに統合**: CIのテスト結果レポートに依存性違反が含まれるため、見落としが減ります
 
 ---
@@ -250,7 +253,7 @@ archunit-goには他のツールにない特長があります。
 
 各ツールの特性を比較します。プロジェクトの状況に応じて使い分けてください。
 
-| 項目 | depguard | go-cleanarch | archunit-go |
+| 項目 | depguard | go-cleanarch | archunit |
 | --- | --- | --- | --- |
 | 導入方法 | golangci-lint に組み込み | スタンドアロンCLI | テストコード |
 | 設定 | YAML（`.golangci.yml`） | 設定不要（命名規約ベース） | Goテストコード |
@@ -259,7 +262,7 @@ archunit-goには他のツールにない特長があります。
 | 実行コマンド | `golangci-lint run` | `go-cleanarch ./...` | `go test ./...` |
 | 推奨シーン | 既にgolangci-lintを使っているプロジェクト | 素早く導入したいとき | 複雑なルールを定義したいとき |
 
-私のチームでは、**depguard をメインに使い、archunit-go で補完する**構成に落ち着きました。depguardはgolangci-lintの一部として毎回実行され、archunit-goはテストスイートの中でより細かいルールを検証します。
+私のチームでは、**depguard をメインに使い、archunit で補完する**構成に落ち着きました。depguardはgolangci-lintの一部として毎回実行され、archunitはテストスイートの中でより細かいルールを検証します。
 
 ---
 
@@ -351,7 +354,7 @@ deny:
 | ------------ | -------------------------------- | ---------- |
 | depguard     | golangci-lint統合、柔軟な設定    | 低い       |
 | go-cleanarch | 設定不要、即座に使える           | 非常に低い |
-| archunit-go  | テストコードで宣言的にルール定義 | 中程度     |
+| archunit     | テストコードで宣言的にルール定義 | 中程度     |
 
 大切なのは、ツールの選択よりも**CIで必須チェックにする**ことです。どんなに良いツールも、実行されなければ意味がありません。まずはgo-cleanarchで現状を把握し、depguardで段階的にルールを厳格化していくのがおすすめです。
 
@@ -362,9 +365,9 @@ deny:
 | 内容 | 出典 |
 | --- | --- |
 | クリーンアーキテクチャ原典 | Robert C. Martin, _Clean Architecture_（2017） |
-| depguard | [OpenPolicyAgent/depguard - GitHub](https://github.com/OpenPolicyAgent/depguard) |
+| depguard | [OpenPeeDeeP/depguard - GitHub](https://github.com/OpenPeeDeeP/depguard) |
 | go-cleanarch | [roblaszczak/go-cleanarch - GitHub](https://github.com/roblaszczak/go-cleanarch) |
-| archunit-go | [nicognaW/archunit-go - GitHub](https://github.com/nicognaW/archunit-go) |
+| archunit | [kcmvp/archunit - GitHub](https://github.com/kcmvp/archunit) |
 | golangci-lint | [golangci-lint 公式ドキュメント](https://golangci-lint.run/) |
 | ArchUnit（JVM版） | [ArchUnit 公式サイト](https://www.archunit.org/) |
 | GitHub Actions ステータスチェック | [GitHub Docs - Protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) |


### PR DESCRIPTION
## Summary

- `OpenPolicyAgent/depguard` を正規の `OpenPeeDeeP/depguard` に訂正（リダイレクト先が新リポジトリのため）
- メンテが止まっている `nicognaW/archunit-go` を `kcmvp/archunit` に差し替え
- 新 API（`ArchLayer` → `ArchUnit` → `Validate` + `ShouldNotRefer`）に合わせてサンプルコードと利点・比較表・参考リンクを書き直し

## Test plan

- [ ] Zenn プレビュー（`npx zenn preview`）で対象記事 `articles/7d2428cbcd258d.md` を開き、URL とコードブロックが正しく描画されることを確認
- [ ] リンク先（depguard / archunit リポジトリ）が 200 で開けることを確認
- [ ] CI（`fmt --check` / `lint`）の Green を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated article on dependency validation tools with revised external references and improved documentation.
  * Enhanced configuration examples and validation patterns for development architecture practices.
  * Refreshed tool comparison tables and updated resource references for team development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->